### PR TITLE
Added obj directory creation to build.sh

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,7 +1,9 @@
-#!/bin/bash 
+#!/bin/bash
 
 if [ -d obj ]; then
     rm -fR obj/*
+else
+    mkdir obj
 fi
 
 cp -fR src/* obj


### PR DESCRIPTION
Created the obj dir when absent to prevent subsequent steps from failing.